### PR TITLE
refacto: make beatLevel to external and use calldata

### DIFF
--- a/src/LevelNFT.sol
+++ b/src/LevelNFT.sol
@@ -50,7 +50,7 @@ contract LevelNFT is ERC721, Ownable {
     }
     
     // Function to beat a level. If successful, adds to this token's score and tracks as beaten by this owner + tokenID.
-    function beatLevel(uint256 level, uint256 tokenId, bytes memory userData) public returns(bool) {
+    function beatLevel(uint256 level, uint256 tokenId, bytes calldata userData) external returns(bool) {
         // Only the owner can call the function to beat the level.
         require(ownerOf[tokenId] == msg.sender);
 


### PR DESCRIPTION
Knowing that only the owner can call the function, I think the function
can use the external modifier. Thanks to this, knowing that the function
is external, we can directly use the userData argument from the calldata
layer to save some gas because it is read-only (in this case, we bypass
the implicit conversion to the memory layer).

----

_Additional context:_
When the functions get called externally, the arguments are kept in calldata
and copied to memory during ABI decoding (using the opcode calldataload and mstore).
When the argument is read in the function, the value is accesses in memory
using a mload. We can avoid all this logic by simply using calldata for
read-only arguments. In my proposal, instead of going via memory,
the value is directly read from calldata using calldataload.