### PR TITLE
refacto: use the pre-increment, instead of the post + unchecked

### DIFF
--- a/src/LevelNFT.sol
+++ b/src/LevelNFT.sol
@@ -40,7 +40,9 @@ contract LevelNFT is ERC721, Ownable {
     function addLevel(address levelAddress, uint256 levelValue) public onlyOwner {
         levels[latestLevel] = ILevelChecker(levelAddress);
         levelValues[latestLevel] = levelValue;
-        latestLevel++;
+        unchecked {
+            ++latestLevel;
+        }
     }
 
     // Helper function to check if this token ID has previously beaten a level.


### PR DESCRIPTION
The pre-increment (++i) operation uses less opcodes and is thus more gas efficient. Additionally, this value will never overflow in a human timeline, we can bypass the automatic overflow check to save gas. I guess there are no small optimizations 🤷‍♂️
